### PR TITLE
Fix homepage route

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,8 @@ if (seo.url === 'glitch-default') {
 
 // Routes
 fastify.get('/wakeup', async (req, reply) => reply.send('Waking up...'));
-fastify.get('/', async (req, reply) => reply.view('/src/pages/index.hbs', { seo }));
+// Serve the homepage using the view plugin's configured root directory
+fastify.get('/', async (req, reply) => reply.view('index.hbs', { seo }));
 
 fastify.get('/login', async (req, reply) => {
   const scopes = ['user-read-private', 'user-read-email', 'user-top-read'];


### PR DESCRIPTION
## Summary
- fix the view path for the homepage so the template resolves correctly

## Testing
- `node server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685c2c3f4e408326b9c931160a25d871