### PR TITLE
Add WXPN playlist Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This project includes a Node.js server script and a web page that connects to it
 
 _Last updated: 14 August 2023_
 
+## WXPN Playlist → Spotify Chrome extension
+
+This repo now includes an `extension/` folder with a Manifest V3 Chrome extension that decorates <https://xpn.org/wxpn-playlists/> with **Add to Spotify** buttons. The buttons post tracks to the server in this project, which forwards them into a Spotify playlist.
+
+**Setup**
+1. Configure environment variables `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI` (default is `http://localhost:3000/callback`), and either set `SPOTIFY_PLAYLIST_ID` or plan to paste a playlist ID into the extension popup.
+2. Start the server with `npm start`.
+3. In Chrome, open **chrome://extensions** → **Load unpacked** and select the `extension` directory.
+4. Open the popup to set the backend URL (for local development use `http://localhost:3000`), choose your playlist ID, and click **Connect Spotify**. After authenticating, visit the WXPN playlist page to add tracks directly.
+
+
 ## Prerequisites
 
 You'll get best use out of this project if you're familiar with basic JavaScript. If you've written JavaScript for client-side web pages this is a little different because it uses server-side JS, but the syntax is the same!

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,13 @@
+# WXPN Playlist → Spotify Chrome extension
+
+This folder contains a Manifest V3 Chrome extension that decorates the WXPN playlist page (https://xpn.org/wxpn-playlists/) with **Add to Spotify** buttons and sends tracks to a configured Spotify playlist through the server in this repo.
+
+## Setup
+1. Ensure the server is running and configured with `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI`, and either `SPOTIFY_PLAYLIST_ID` or a playlist ID you will paste into the popup.
+2. Load the extension in Chrome via **chrome://extensions** > **Load unpacked** and select the `extension` directory.
+3. Open the popup, set your backend URL (e.g., `http://localhost:3000`) and target playlist ID, then click **Connect Spotify** to run the OAuth flow.
+4. Visit the WXPN playlist page; each track row will gain an **Add to Spotify** button that posts the song and artist to the server.
+
+## Notes
+- The extension uses heuristic selectors to find song/artist pairs in tables or playlist items on the page. If buttons are missing, reload the page after the playlist renders.
+- Toast messages will confirm success or surface errors (such as needing to reconnect Spotify).

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,87 @@
+const DEFAULT_SETTINGS = {
+  backendBaseUrl: 'http://localhost:3000',
+  playlistId: ''
+};
+
+async function getSettings() {
+  const stored = await chrome.storage.sync.get(DEFAULT_SETTINGS);
+  return { ...DEFAULT_SETTINGS, ...stored };
+}
+
+async function saveSettings(settings) {
+  await chrome.storage.sync.set(settings);
+  return getSettings();
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchSession() {
+  const { backendBaseUrl } = await getSettings();
+  return fetchJson(`${backendBaseUrl}/api/session`).catch((error) => ({
+    authenticated: false,
+    error: error.message
+  }));
+}
+
+async function startLoginFlow() {
+  const { backendBaseUrl } = await getSettings();
+  const { authorizeUrl } = await fetchJson(`${backendBaseUrl}/api/login`);
+  await chrome.tabs.create({ url: authorizeUrl });
+  return { started: true, authorizeUrl };
+}
+
+async function addTrackToPlaylist(track) {
+  const { backendBaseUrl, playlistId } = await getSettings();
+  if (!playlistId) {
+    throw new Error('Set a target playlist ID in the extension popup first.');
+  }
+
+  return fetchJson(`${backendBaseUrl}/api/add-track`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      trackName: track.trackName,
+      artistName: track.artistName,
+      playlistId
+    })
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  (async () => {
+    try {
+      switch (message?.type) {
+        case 'GET_SETTINGS':
+          sendResponse(await getSettings());
+          break;
+        case 'SET_SETTINGS':
+          sendResponse(await saveSettings(message.settings || {}));
+          break;
+        case 'GET_SESSION':
+          sendResponse(await fetchSession());
+          break;
+        case 'START_LOGIN':
+          sendResponse(await startLoginFlow());
+          break;
+        case 'ADD_TRACK':
+          sendResponse(await addTrackToPlaylist(message.track));
+          break;
+        default:
+          sendResponse({});
+      }
+    } catch (error) {
+      sendResponse({ error: error.message });
+    }
+  })();
+
+  return true;
+});

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -1,0 +1,110 @@
+const BUTTON_CLASS = 'xpn-spotify-add-button';
+const ATTACHED_FLAG = 'data-spotify-button';
+
+const debounce = (fn, delay = 300) => {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+};
+
+function findTableCandidates() {
+  const candidates = [];
+  document.querySelectorAll('table').forEach((table) => {
+    const headers = Array.from(table.querySelectorAll('th')).map((th) => th.textContent.trim().toLowerCase());
+    const songIndex = headers.findIndex((text) => text.includes('song') || text.includes('title'));
+    const artistIndex = headers.findIndex((text) => text.includes('artist'));
+
+    if (songIndex === -1 || artistIndex === -1) return;
+
+    const rows = table.querySelectorAll('tbody tr, tr');
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll('td');
+      if (!cells.length) return;
+      const trackName = cells[songIndex]?.textContent?.trim();
+      const artistName = cells[artistIndex]?.textContent?.trim();
+      if (trackName && artistName) {
+        candidates.push({ row, trackName, artistName });
+      }
+    });
+  });
+  return candidates;
+}
+
+function findDataAttributeCandidates() {
+  const selectors = [
+    '[data-song-title]',
+    '[data-track-title]',
+    '.song-title',
+    '.track-title'
+  ];
+  const candidates = [];
+  selectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((titleEl) => {
+      const container = titleEl.closest('[data-artist-name], .playlist-item, li, article, div');
+      const artistEl = container?.querySelector('[data-artist-name], .artist-name');
+      const trackName = titleEl.textContent?.trim();
+      const artistName = artistEl?.textContent?.trim();
+      if (container && trackName && artistName) {
+        candidates.push({ row: container, trackName, artistName });
+      }
+    });
+  });
+  return candidates;
+}
+
+function getTrackCandidates() {
+  const merged = [...findTableCandidates(), ...findDataAttributeCandidates()];
+  const seen = new Set();
+  return merged.filter(({ row, trackName, artistName }) => {
+    const key = `${trackName}-${artistName}`.toLowerCase();
+    if (seen.has(key)) return false;
+    if (row.hasAttribute(ATTACHED_FLAG)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function showToast(message, type = 'info') {
+  const toast = document.createElement('div');
+  toast.className = `xpn-spotify-toast xpn-spotify-toast-${type}`;
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add('visible');
+  }, 50);
+  setTimeout(() => {
+    toast.classList.remove('visible');
+    toast.addEventListener('transitionend', () => toast.remove());
+  }, 3200);
+}
+
+function attachButtons() {
+  const candidates = getTrackCandidates();
+  candidates.forEach((candidate) => {
+    const button = document.createElement('button');
+    button.textContent = 'Add to Spotify';
+    button.className = BUTTON_CLASS;
+    button.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'ADD_TRACK', track: candidate }, (response) => {
+        if (!response || response.error) {
+          const reason = response?.error || 'Unable to add track. Confirm Spotify login in the extension popup.';
+          showToast(reason, 'error');
+          return;
+        }
+        showToast(`Added ${candidate.trackName} to Spotify`, 'success');
+      });
+    });
+    candidate.row.setAttribute(ATTACHED_FLAG, 'true');
+    candidate.row.classList.add('xpn-spotify-row');
+    candidate.row.appendChild(button);
+  });
+}
+
+const debouncedAttach = debounce(attachButtons, 300);
+
+attachButtons();
+
+const observer = new MutationObserver(() => debouncedAttach());
+observer.observe(document.body, { childList: true, subtree: true });

--- a/extension/contentStyles.css
+++ b/extension/contentStyles.css
@@ -1,0 +1,49 @@
+.xpn-spotify-add-button {
+  margin-left: 10px;
+  padding: 6px 10px;
+  background: #1db954;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.xpn-spotify-add-button:hover {
+  background: #159741;
+}
+
+.xpn-spotify-row {
+  position: relative;
+}
+
+.xpn-spotify-toast {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  padding: 12px 16px;
+  color: #fff;
+  background: #333;
+  border-radius: 6px;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  transform: translateY(10px);
+  z-index: 9999;
+}
+
+.xpn-spotify-toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.xpn-spotify-toast-success {
+  background: #1db954;
+}
+
+.xpn-spotify-toast-error {
+  background: #c0392b;
+}
+
+.xpn-spotify-toast-info {
+  background: #2980b9;
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 3,
+  "name": "WXPN Playlist to Spotify",
+  "version": "1.0.0",
+  "description": "Send tracks from the WXPN playlist page to a Spotify playlist.",
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://xpn.org/wxpn-playlists/*",
+    "http://*/*",
+    "https://*/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://xpn.org/wxpn-playlists/*"],
+      "js": ["contentScript.js"],
+      "css": ["contentStyles.css"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Send WXPN songs to Spotify"
+  }
+}

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,66 @@
+body {
+  min-width: 320px;
+  margin: 0;
+  padding: 16px;
+  font-family: Arial, sans-serif;
+  background: #f7f7f7;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.section {
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+button {
+  flex: 1;
+  padding: 10px;
+  font-weight: 600;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: #1db954;
+  color: #fff;
+}
+
+button#saveSettings {
+  background: #34495e;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+.status {
+  font-size: 13px;
+  margin-top: 8px;
+}
+
+.small {
+  color: #555;
+  margin: 0 0 8px;
+  font-size: 13px;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>WXPN to Spotify</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <h1>WXPN → Spotify</h1>
+    <p class="small">Connect Spotify and choose the playlist that will receive tracks from xpn.org.</p>
+
+    <div class="section">
+      <label for="backendBaseUrl">Backend URL</label>
+      <input id="backendBaseUrl" type="text" placeholder="http://localhost:3000" />
+    </div>
+
+    <div class="section">
+      <label for="playlistId">Spotify Playlist ID</label>
+      <input id="playlistId" type="text" placeholder="Your target playlist ID" />
+    </div>
+
+    <div class="actions">
+      <button id="saveSettings">Save Settings</button>
+      <button id="startLogin">Connect Spotify</button>
+    </div>
+
+    <div id="status" class="status">Checking Spotify session…</div>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,56 @@
+const backendInput = document.getElementById('backendBaseUrl');
+const playlistInput = document.getElementById('playlistId');
+const statusEl = document.getElementById('status');
+
+function setStatus(text, isError = false) {
+  statusEl.textContent = text;
+  statusEl.style.color = isError ? '#c0392b' : '#2c3e50';
+}
+
+function loadSettings() {
+  chrome.runtime.sendMessage({ type: 'GET_SETTINGS' }, (settings) => {
+    backendInput.value = settings.backendBaseUrl;
+    playlistInput.value = settings.playlistId;
+  });
+}
+
+function checkSession() {
+  setStatus('Checking Spotify session…');
+  chrome.runtime.sendMessage({ type: 'GET_SESSION' }, (response) => {
+    if (response?.authenticated) {
+      setStatus(`Connected as ${response.user.display_name}`);
+    } else {
+      const reason = response?.error || 'Not connected to Spotify';
+      setStatus(reason, true);
+    }
+  });
+}
+
+function saveSettings() {
+  chrome.runtime.sendMessage({
+    type: 'SET_SETTINGS',
+    settings: {
+      backendBaseUrl: backendInput.value.trim(),
+      playlistId: playlistInput.value.trim()
+    }
+  }, () => {
+    setStatus('Settings saved.');
+  });
+}
+
+function startLogin() {
+  setStatus('Opening Spotify login…');
+  chrome.runtime.sendMessage({ type: 'START_LOGIN' }, (response) => {
+    if (response?.error) {
+      setStatus(response.error, true);
+      return;
+    }
+    setStatus('Complete the Spotify login in the opened tab.');
+  });
+}
+
+loadSettings();
+checkSession();
+
+document.getElementById('saveSettings').addEventListener('click', saveSettings);
+document.getElementById('startLogin').addEventListener('click', startLogin);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "@fastify/cors": "^9.0.1",
     "fastify": "^4.25.2",
     "handlebars": "^4.7.8",
     "@fastify/formbody": "^7.4.0",

--- a/server.js
+++ b/server.js
@@ -1,16 +1,31 @@
 require('dotenv').config();
 const path = require('path');
 const fastify = require('fastify')({ logger: true });
+const cors = require('@fastify/cors');
 const SpotifyWebApi = require('spotify-web-api-node');
 
 // Initialize Spotify API client
 const spotifyApi = new SpotifyWebApi({
   clientId: process.env.SPOTIFY_CLIENT_ID,
   clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-  redirectUri: 'https://xpnplaylist.glitch.me/callback'
+  redirectUri: process.env.SPOTIFY_REDIRECT_URI || 'http://localhost:3000/callback'
 });
 
+// OAuth scopes used across web and extension flows
+const spotifyScopes = [
+  'user-read-private',
+  'playlist-modify-public',
+  'playlist-modify-private'
+];
+
+let tokenExpiresAt = 0;
+
 // Fastify plugin setup
+fastify.register(cors, {
+  origin: true,
+  methods: ['GET', 'POST', 'OPTIONS']
+});
+
 fastify.register(require('@fastify/static'), {
   root: path.join(__dirname, 'public'),
   prefix: '/'
@@ -27,13 +42,38 @@ if (seo.url === 'glitch-default') {
   seo.url = `https://${process.env.PROJECT_DOMAIN}.glitch.me`;
 }
 
+const setTokens = (data) => {
+  spotifyApi.setAccessToken(data.body['access_token']);
+  spotifyApi.setRefreshToken(data.body['refresh_token']);
+  tokenExpiresAt = Date.now() + data.body['expires_in'] * 1000;
+};
+
+const ensureAccessToken = async () => {
+  if (!spotifyApi.getAccessToken()) {
+    throw new Error('Spotify is not authenticated');
+  }
+
+  if (tokenExpiresAt && Date.now() >= tokenExpiresAt - 30_000) {
+    const refreshed = await spotifyApi.refreshAccessToken();
+    spotifyApi.setAccessToken(refreshed.body['access_token']);
+    if (refreshed.body['refresh_token']) {
+      spotifyApi.setRefreshToken(refreshed.body['refresh_token']);
+    }
+    tokenExpiresAt = Date.now() + refreshed.body['expires_in'] * 1000;
+  }
+};
+
 // Routes
 fastify.get('/wakeup', async (req, reply) => reply.send('Waking up...'));
 fastify.get('/', async (req, reply) => reply.view('/src/pages/index.hbs', { seo }));
 
 fastify.get('/login', async (req, reply) => {
-  const scopes = ['user-read-private', 'user-read-email', 'user-top-read'];
-  reply.redirect(spotifyApi.createAuthorizeURL(scopes));
+  reply.redirect(spotifyApi.createAuthorizeURL(spotifyScopes));
+});
+
+fastify.get('/api/login', async (req, reply) => {
+  const state = 'extension';
+  return reply.send({ authorizeUrl: spotifyApi.createAuthorizeURL(spotifyScopes, state) });
 });
 
 fastify.get('/callback', async (req, reply) => {
@@ -43,27 +83,78 @@ fastify.get('/callback', async (req, reply) => {
     }
 
     const data = await spotifyApi.authorizationCodeGrant(req.query.code);
-    spotifyApi.setAccessToken(data.body['access_token']);
-    spotifyApi.setRefreshToken(data.body['refresh_token']);
+    setTokens(data);
 
     const [me, topTracks] = await Promise.all([
       spotifyApi.getMe(),
       spotifyApi.getMyTopTracks()
     ]);
 
-return reply.view('index.hbs', {
-  name: me.body.display_name,
-  topTracks: topTracks.body.items,
-  seo
-});
+    if (req.query.state === 'extension') {
+      return reply.type('text/html').send('<p>Spotify is connected. You can close this tab and continue in the extension.</p>');
+    }
+
+    return reply.view('index.hbs', {
+      name: me.body.display_name,
+      topTracks: topTracks.body.items,
+      seo
+    });
   } catch (error) {
     console.error(error);
     return reply.status(500).send('Authentication error');
   }
 });
 
+fastify.get('/api/session', async (req, reply) => {
+  try {
+    await ensureAccessToken();
+    const me = await spotifyApi.getMe();
+    return reply.send({ authenticated: true, user: me.body, tokenExpiresAt });
+  } catch (error) {
+    return reply.send({ authenticated: false, error: error.message });
+  }
+});
+
+fastify.post('/api/add-track', async (req, reply) => {
+  const { trackName, artistName, playlistId } = req.body || {};
+  if (!trackName) {
+    return reply.status(400).send({ error: 'trackName is required' });
+  }
+
+  const targetPlaylist = playlistId || process.env.SPOTIFY_PLAYLIST_ID;
+  if (!targetPlaylist) {
+    return reply.status(400).send({ error: 'No playlistId provided and SPOTIFY_PLAYLIST_ID is not set' });
+  }
+
+  try {
+    await ensureAccessToken();
+    const query = artistName ? `track:${trackName} artist:${artistName}` : trackName;
+    const searchResults = await spotifyApi.searchTracks(query, { limit: 1 });
+    const track = searchResults.body.tracks?.items?.[0];
+
+    if (!track) {
+      return reply.status(404).send({ error: 'No matching track found on Spotify' });
+    }
+
+    await spotifyApi.addTracksToPlaylist(targetPlaylist, [track.uri]);
+
+    return reply.send({
+      added: true,
+      track: {
+        name: track.name,
+        artists: track.artists.map((artist) => artist.name),
+        uri: track.uri
+      }
+    });
+  } catch (error) {
+    console.error('Error adding track to playlist', error);
+    return reply.status(500).send({ error: 'Failed to add track to playlist' });
+  }
+});
+
 fastify.get('/top-tracks', async (req, reply) => {
   try {
+    await ensureAccessToken();
     const topTracks = await spotifyApi.getMyTopTracks();
     reply.view('nametracks.hbs', { tracks: topTracks.body.items });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add CORS, authentication helpers, and playlist-add API endpoints to support extension-driven Spotify actions
- create a Chrome extension that decorates the WXPN playlist page with Add to Spotify buttons and routes clicks through the server
- document extension setup and configuration details in the README

## Testing
- npm install *(fails: registry returned 403 for @fastify/cors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f424b91508326ad4d3a636d93ebdd)